### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,28 @@ A DNS-over-HTTP server proxy in Rust. Add a webserver and you get DNS-over-HTTPS
 
 ## Installation
 
+Install Rust by an official recommended way:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
 Without built-in support for HTTPS:
 
 ```sh
-cargo install doh-proxy
+cargo install --force --root '/usr/local/doh/' --git 'https://github.com/jedisct1/rust-doh.git'
 ```
 
 With built-in support for HTTPS (requires openssl-dev):
 
 ```sh
-cargo install doh-proxy --features=tls
+cargo install --force --root '/usr/local/doh/' --git 'https://github.com/jedisct1/rust-doh.git' --features=tls
+```
+
+Be sure to add `/usr/local/doh/bin` to your `$PATH` to be able to run the installed binaries:
+
+```sh
+export PATH=$PATH:/usr/local/doh/bin
 ```
 
 ## Usage


### PR DESCRIPTION
#### Refer to the cargo help information, the default behavior of cargo-install tool is to fetch source from [crates.io](https://crates.io/). As the published version on [crates.io](https://crates.io/) may not updated, it is better to change the instructions in this document from my perspective.

### $ cargo help install
...
There are multiple sources from which a crate can be installed. **The default**
**location is crates.io** but the `--git`, `--path`, and `registry` flags can
change this source. If the source contains more than one package (such as
crates.io or a git repository with multiple crates) the `<crate>` argument is
required to indicate which crate should be installed.
...
